### PR TITLE
アクセスカウンターのHTTPS対応。

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <head>
 <title>GOROman's Homepage</title>
 <meta name="GENERATOR" content="IBM WebSphere Studio Homepage Builder Version 6.5.0.0 for Windows">
+<meta charset="utf-8">
 </head>
 <body onContextmenu="window.alert('右クリック禁止です。');return false"></body>
 <body>
@@ -14,13 +15,12 @@ Sorry, Japanese Only!!
 <br>
 <hr>
 
-あなたは <br>
-<table border="0" cellspacing="0" cellpadding="0"><tr><td align="center">
-    <div style="width:6em; background:black;">
-        <img src="https://clone-of-ryan-lanciaux-counter.glitch.me/count.svg" alt="アクセスカウンター" style="max-width: 100%;">
-    </div>
-</td></tr></table>
-番目のお客さんです。<br>
+<div>あなたは </div>
+<div style="background:black; width:6em; padding:0.2em 0 0.2em 0">
+  <object data="https://seven-seg-font-8888-counter.glitch.me/count.html" type="text/html" style="height:18px; width:92px;">アクセスカウンター</object>
+</div>
+<div>番目のお客さんです。</div>
+<br>
 <br>
 <br>
 <table border="2">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,11 @@ Sorry, Japanese Only!!
 <hr>
 
 あなたは <br>
-<table border="0" cellspacing="0" cellpadding="0"><tr><td align="center"><a href="http://www.rays-counter.com/"><img src="http://www.rays-counter.com/d457_f6_022/5ea53c57d2ce6/" alt="アクセスカウンター" border="0"></a></td></tr><tr><td align="center" style="font-size:xx-small"><img src="http://www.rays-counter.com/images/counter_01.gif" border="0"><img src="http://www.rays-counter.com/images/counter_02.gif" border="0"><img src="http://www.rays-counter.com/images/counter_03.gif" border="0"><img src="http://www.rays-counter.com/images/counter_04.gif" border="0"><img src="http://www.rays-counter.com/images/counter_05.gif" border="0"></td></tr></table>
+<table border="0" cellspacing="0" cellpadding="0"><tr><td align="center">
+    <div style="width:6em; background:black;">
+        <a target="_blank" rel="noopener noreferrer nofollow" href="https://camo.githubusercontent.com/3de75c43d71bcca084acc68feefe0bff902bba4e7e86e529f2bfbc16362f076a/68747470733a2f2f636c6f6e652d6f662d7279616e2d6c616e63696175782d636f756e7465722e676c697463682e6d652f636f756e742e737667"><img src="https://camo.githubusercontent.com/3de75c43d71bcca084acc68feefe0bff902bba4e7e86e529f2bfbc16362f076a/68747470733a2f2f636c6f6e652d6f662d7279616e2d6c616e63696175782d636f756e7465722e676c697463682e6d652f636f756e742e737667" alt="アクセスカウンター" data-canonical-src="https://clone-of-ryan-lanciaux-counter.glitch.me/count.svg" style="max-width: 100%;"></a>
+    </div>
+</td></tr></table>
 番目のお客さんです。<br>
 <br>
 <br>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ Sorry, Japanese Only!!
 あなたは <br>
 <table border="0" cellspacing="0" cellpadding="0"><tr><td align="center">
     <div style="width:6em; background:black;">
-        <a target="_blank" rel="noopener noreferrer nofollow" href="https://camo.githubusercontent.com/3de75c43d71bcca084acc68feefe0bff902bba4e7e86e529f2bfbc16362f076a/68747470733a2f2f636c6f6e652d6f662d7279616e2d6c616e63696175782d636f756e7465722e676c697463682e6d652f636f756e742e737667"><img src="https://camo.githubusercontent.com/3de75c43d71bcca084acc68feefe0bff902bba4e7e86e529f2bfbc16362f076a/68747470733a2f2f636c6f6e652d6f662d7279616e2d6c616e63696175782d636f756e7465722e676c697463682e6d652f636f756e742e737667" alt="アクセスカウンター" data-canonical-src="https://clone-of-ryan-lanciaux-counter.glitch.me/count.svg" style="max-width: 100%;"></a>
+        <img src="https://clone-of-ryan-lanciaux-counter.glitch.me/count.svg" alt="アクセスカウンター" style="max-width: 100%;">
     </div>
 </td></tr></table>
 番目のお客さんです。<br>


### PR DESCRIPTION
Glitchにアカウント(無料版)を作り、[この方のソース](https://dev.to/ryanlanciaux/quick-github-profile-visit-counter-14en)を[パクって](https://glitch.com/~clone-of-ryan-lanciaux-counter)とりあえず113,000から開始にしときました。たまにカウンターが表示されません。無料アカウントなので、5分アクセスがないとスリープして読み込みに時間がかかります(回避措置としてGASで5分おきにポーリングしています)