### PR TITLE
デプロイ構成修正: MDXプレーヤーを/mdx/に配置

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Build Vite app
         run: npm run build
+
+      - name: Prepare deploy directory
+        run: |
+          mkdir -p deploy
+          # Copy original static files
+          cp index.old.html deploy/index.html
+          cp irc.html deploy/ 2>/dev/null || true
+          # Copy Vite build output to mdx/
+          mkdir -p deploy/mdx
+          cp -r dist/* deploy/mdx/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -42,7 +52,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './dist'
+          path: './deploy'
 
   deploy:
     environment:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import path from 'path'
 
 export default defineConfig(({ command }) => ({
   plugins: [react()],
-  base: command === 'serve' ? '/' : './',
+  base: command === 'serve' ? '/' : '/mdx/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- Viteのbaseを`/mdx/`に変更
- index.old.htmlをルートのindex.htmlとしてデプロイ
- Viteビルド出力をmdx/ディレクトリに配置

## デプロイ後の構成
- `https://goroman.github.io/` → 元のレトロなホームページ
- `https://goroman.github.io/mdx/` → React版MDXプレーヤー
- `https://goroman.github.io/irc.html` → IRCガイド

🤖 Generated with [Claude Code](https://claude.com/claude-code)