### PR TITLE
プレイリスト（曲セレクター）機能を追加

### DIFF
--- a/mdx/index.html
+++ b/mdx/index.html
@@ -10,6 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=Orbitron:wght@400;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
   <link href="style.css" rel="stylesheet">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <title>WASM MDXPlayer Powered by Claude Code</title>
 </head>
 
@@ -80,6 +81,21 @@
           <canvas id="level-canvas" width="320" height="120"></canvas>
         </div>
       </div>
+
+      <!-- Playlist Panel -->
+      <div id="playlist-panel" class="panel">
+        <div class="panel-header">
+          <span>PLAYLIST</span>
+          <span id="playlist-count">[00/00]</span>
+          <div class="playlist-controls">
+            <button id="btn-autoplay" class="playlist-btn active" title="Auto Play">AUTO</button>
+            <button id="btn-clear-playlist" class="playlist-btn" title="Clear Playlist">CLR</button>
+          </div>
+        </div>
+        <div id="playlist-container" tabindex="0">
+          <ul id="playlist-list"></ul>
+        </div>
+      </div>
     </div>
 
     <!-- Footer -->
@@ -93,9 +109,8 @@
         <span>PDX: <span id="pdxfile">-</span></span>
       </div>
       <div id="drop-zone">
-        .MDX / .PDX Drag & Drop
-        <input type="file" id="mdxfile1" accept=".mdx" hidden>
-        <input type="file" id="pdxfile1" accept=".pdx" hidden>
+        .MDX / .PDX / .ZIP Drag & Drop
+        <input type="file" id="mdxfile1" accept=".mdx,.pdx,.zip" hidden multiple>
       </div>
     </footer>
 

--- a/mdx/style.css
+++ b/mdx/style.css
@@ -346,6 +346,138 @@ body {
   image-rendering: pixelated;
 }
 
+/* Playlist Panel */
+#playlist-panel {
+  margin: 0 10px 10px 10px;
+}
+
+#playlist-panel .panel-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#playlist-panel .panel-header span:first-child {
+  flex: 0 0 auto;
+}
+
+#playlist-count {
+  color: var(--text-dim);
+  font-size: 10px;
+  flex: 1;
+}
+
+.playlist-controls {
+  display: flex;
+  gap: 4px;
+}
+
+.playlist-btn {
+  background: linear-gradient(to bottom, #202050 0%, #101030 100%);
+  border: 1px solid var(--border-color);
+  border-radius: 2px;
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 9px;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: all 0.1s;
+}
+
+.playlist-btn:hover {
+  background: linear-gradient(to bottom, #303070 0%, #202050 100%);
+  color: var(--text-cyan);
+}
+
+.playlist-btn.active {
+  background: linear-gradient(to bottom, #204060 0%, #103050 100%);
+  color: var(--text-primary);
+  border-color: #306080;
+}
+
+#playlist-container {
+  max-height: 150px;
+  overflow-y: auto;
+  background: #000008;
+  outline: none;
+}
+
+#playlist-container:focus {
+  outline: 1px solid var(--border-light);
+}
+
+#playlist-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.playlist-item {
+  padding: 4px 8px;
+  cursor: pointer;
+  font-family: 'MS Gothic', 'Share Tech Mono', monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid #101020;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: background 0.1s;
+}
+
+.playlist-item:hover {
+  background: #181840;
+}
+
+.playlist-item.selected {
+  background: linear-gradient(to bottom, #202060 0%, #101040 100%);
+  color: #a0a0ff;
+}
+
+.playlist-item.playing {
+  color: var(--text-primary);
+}
+
+.playlist-item.playing::before {
+  content: '\25B6';
+  color: var(--text-primary);
+  font-size: 8px;
+  margin-right: 4px;
+}
+
+.playlist-item .item-number {
+  width: 24px;
+  color: var(--text-dim);
+  font-size: 10px;
+  text-align: right;
+}
+
+.playlist-item .item-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.playlist-item .item-filename {
+  color: var(--text-dim);
+  font-size: 9px;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Playlist empty state */
+#playlist-list:empty::after {
+  content: 'Drop MDX/PDX/ZIP files here';
+  display: block;
+  padding: 20px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
 /* Footer */
 #mmdsp-footer {
   background: linear-gradient(to bottom, #101030 0%, #080820 100%);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mdx-player",
       "version": "0.12.0",
       "dependencies": {
+        "jszip": "^3.10.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2157,6 +2158,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2714,6 +2721,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2740,6 +2753,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2802,6 +2821,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2887,6 +2912,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2909,6 +2946,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -3144,6 +3190,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -3399,6 +3451,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3474,6 +3532,21 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -3600,6 +3673,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3618,6 +3697,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3650,6 +3735,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3954,7 +4048,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "jszip": "^3.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -1,43 +1,116 @@
 import { useState, useCallback, useRef } from 'react';
 import { useMDXPlayer } from '@/contexts/MDXPlayerContext';
+import type { PlaylistItem } from '@/lib/types';
+import JSZip from 'jszip';
 
 export function DropZone() {
-  const { loadMDX, loadPDX, play } = useMDXPlayer();
+  const { addToPlaylist, playSelectedItem, playlist } = useMDXPlayer();
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const readFileAsync = useCallback((file: File): Promise<ArrayBuffer> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = (e) => resolve(e.target?.result as ArrayBuffer);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(file);
+    });
+  }, []);
+
+  const processZipFile = useCallback(
+    async (zipFile: File) => {
+      try {
+        const zip = await JSZip.loadAsync(zipFile);
+        const mdxEntries: { path: string; filename: string; zipEntry: JSZip.JSZipObject }[] = [];
+        const pdxCache: Record<string, { filename: string; data: ArrayBuffer }> = {};
+
+        // First pass: collect all files
+        for (const [path, zipEntry] of Object.entries(zip.files)) {
+          if (zipEntry.dir) continue;
+
+          const filename = path.split('/').pop() || '';
+          if (filename.match(/\.mdx$/i)) {
+            mdxEntries.push({ path, filename, zipEntry });
+          } else if (filename.match(/\.pdx$/i)) {
+            const data = await zipEntry.async('arraybuffer');
+            pdxCache[filename.toUpperCase()] = { filename, data };
+          }
+        }
+
+        // Second pass: create playlist items
+        for (const mdx of mdxEntries) {
+          const mdxData = await mdx.zipEntry.async('arraybuffer');
+
+          // Try to find matching PDX (same name)
+          const pdxName = mdx.filename.replace(/\.mdx$/i, '.PDX').toUpperCase();
+          const pdxInfo = pdxCache[pdxName];
+
+          const item: PlaylistItem = {
+            id: crypto.randomUUID(),
+            mdxFilename: mdx.filename,
+            mdxData,
+            pdxFilename: pdxInfo?.filename || null,
+            pdxData: pdxInfo?.data || null,
+            title: null,
+          };
+
+          addToPlaylist(item);
+        }
+      } catch (err) {
+        console.error('ZIP processing error:', err);
+      }
+    },
+    [addToPlaylist]
+  );
+
   const handleFiles = useCallback(
-    (files: FileList) => {
+    async (files: FileList) => {
       const fileArray = Array.from(files);
 
-      // Load PDX files first
-      fileArray
-        .filter((file) => file.name.match(/\.pdx$/i))
-        .forEach((file) => {
-          const reader = new FileReader();
-          reader.onload = (event) => {
-            if (event.target?.result) {
-              loadPDX(file.name, event.target.result as ArrayBuffer);
-            }
-          };
-          reader.readAsArrayBuffer(file);
-        });
+      // Separate files by type
+      const zipFiles = fileArray.filter((f) => f.name.match(/\.zip$/i));
+      const mdxFiles = fileArray.filter((f) => f.name.match(/\.mdx$/i));
+      const pdxFiles = fileArray.filter((f) => f.name.match(/\.pdx$/i));
 
-      // Then load MDX files
-      fileArray
-        .filter((file) => file.name.match(/\.mdx$/i))
-        .forEach((file) => {
-          const reader = new FileReader();
-          reader.onload = (event) => {
-            if (event.target?.result) {
-              loadMDX(file.name, event.target.result as ArrayBuffer);
-              play();
-            }
-          };
-          reader.readAsArrayBuffer(file);
-        });
+      // Process ZIP files
+      for (const zipFile of zipFiles) {
+        await processZipFile(zipFile);
+      }
+
+      // Read PDX files into cache
+      const pdxCache: Record<string, { filename: string; data: ArrayBuffer }> = {};
+      for (const pdxFile of pdxFiles) {
+        const data = await readFileAsync(pdxFile);
+        pdxCache[pdxFile.name.toUpperCase()] = { filename: pdxFile.name, data };
+      }
+
+      // Process MDX files
+      for (const mdxFile of mdxFiles) {
+        const mdxData = await readFileAsync(mdxFile);
+
+        // Try to find matching PDX
+        const pdxName = mdxFile.name.replace(/\.mdx$/i, '.PDX').toUpperCase();
+        const pdxInfo = pdxCache[pdxName];
+
+        const item: PlaylistItem = {
+          id: crypto.randomUUID(),
+          mdxFilename: mdxFile.name,
+          mdxData,
+          pdxFilename: pdxInfo?.filename || null,
+          pdxData: pdxInfo?.data || null,
+          title: null,
+        };
+
+        addToPlaylist(item);
+      }
+
+      // Auto-play first item if this is the first drop
+      if (playlist.playingIndex === -1 && playlist.items.length === 0) {
+        // Need to wait for state update
+        setTimeout(() => playSelectedItem(), 100);
+      }
     },
-    [loadMDX, loadPDX, play]
+    [addToPlaylist, processZipFile, readFileAsync, playlist.playingIndex, playlist.items.length, playSelectedItem]
   );
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -94,14 +167,14 @@ export function DropZone() {
       <input
         ref={fileInputRef}
         type="file"
-        accept=".mdx,.pdx"
+        accept=".mdx,.pdx,.zip"
         multiple
         onChange={handleFileChange}
         className="hidden"
       />
       {isDragging
-        ? 'Drop MDX/PDX files here'
-        : 'Drop MDX/PDX files here or click to select'}
+        ? 'Drop MDX/PDX/ZIP files here'
+        : 'Drop MDX/PDX/ZIP files here or click to select'}
     </div>
   );
 }

--- a/src/components/MDXPlayer.tsx
+++ b/src/components/MDXPlayer.tsx
@@ -4,6 +4,7 @@ import { Header } from './Header';
 import { ControlPanel } from './ControlPanel';
 import { DropZone } from './DropZone';
 import { Credit } from './Credit';
+import { Playlist } from './Playlist';
 import { KeyboardVisualizer } from './visualizers/KeyboardVisualizer';
 import { LevelMeter } from './visualizers/LevelMeter';
 import { SpectrumAnalyzer } from './visualizers/SpectrumAnalyzer';
@@ -91,6 +92,9 @@ export function MDXPlayer() {
               <ControlPanel />
             </div>
           )}
+
+          {/* Playlist */}
+          <Playlist />
         </div>
 
         {/* Footer */}

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useRef, useEffect } from 'react';
+import { useMDXPlayer } from '@/contexts/MDXPlayerContext';
+
+export function Playlist() {
+  const {
+    playlist,
+    selectPlaylistItem,
+    playSelectedItem,
+    removeFromPlaylist,
+    clearPlaylist,
+    toggleAutoPlay,
+  } = useMDXPlayer();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLLIElement>(null);
+
+  // Scroll to selected item
+  useEffect(() => {
+    if (selectedRef.current) {
+      selectedRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [playlist.currentIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowUp':
+          e.preventDefault();
+          if (playlist.currentIndex > 0) {
+            selectPlaylistItem(playlist.currentIndex - 1);
+          }
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          if (playlist.currentIndex < playlist.items.length - 1) {
+            selectPlaylistItem(playlist.currentIndex + 1);
+          }
+          break;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          playSelectedItem();
+          break;
+        case 'Delete':
+        case 'Backspace':
+          e.preventDefault();
+          if (playlist.currentIndex >= 0) {
+            removeFromPlaylist(playlist.currentIndex);
+          }
+          break;
+      }
+    },
+    [playlist.currentIndex, playlist.items.length, selectPlaylistItem, playSelectedItem, removeFromPlaylist]
+  );
+
+  const handleItemClick = useCallback(
+    (index: number) => {
+      selectPlaylistItem(index);
+    },
+    [selectPlaylistItem]
+  );
+
+  const handleItemDoubleClick = useCallback(
+    (index: number) => {
+      selectPlaylistItem(index);
+      playSelectedItem();
+    },
+    [selectPlaylistItem, playSelectedItem]
+  );
+
+  const currentNum = playlist.playingIndex >= 0 ? playlist.playingIndex + 1 : 0;
+  const totalNum = playlist.items.length;
+
+  return (
+    <div className="mmdsp-panel mx-[10px] mb-[10px]">
+      <div className="mmdsp-panel-header flex items-center gap-2.5">
+        <span>PLAYLIST</span>
+        <span className="text-[10px] text-[#303080] flex-1">
+          [{String(currentNum).padStart(2, '0')}/{String(totalNum).padStart(2, '0')}]
+        </span>
+        <div className="flex gap-1">
+          <button
+            onClick={toggleAutoPlay}
+            className={`mmdsp-playlist-btn ${playlist.isAutoPlay ? 'active' : ''}`}
+            title="Auto Play"
+          >
+            AUTO
+          </button>
+          <button
+            onClick={clearPlaylist}
+            className="mmdsp-playlist-btn"
+            title="Clear Playlist"
+          >
+            CLR
+          </button>
+        </div>
+      </div>
+      <div
+        ref={containerRef}
+        className="max-h-[150px] overflow-y-auto bg-[#000008] outline-none focus:outline focus:outline-1 focus:outline-[#3030a0]"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+      >
+        <ul className="list-none p-0 m-0">
+          {playlist.items.length === 0 ? (
+            <li className="p-5 text-center text-[11px] text-[#303080]">
+              Drop MDX/PDX/ZIP files here
+            </li>
+          ) : (
+            playlist.items.map((item, index) => (
+              <li
+                key={item.id}
+                ref={index === playlist.currentIndex ? selectedRef : null}
+                onClick={() => handleItemClick(index)}
+                onDoubleClick={() => handleItemDoubleClick(index)}
+                className={`
+                  flex items-center gap-2 px-2 py-1 cursor-pointer
+                  font-['MS_Gothic','Share_Tech_Mono',monospace] text-[11px]
+                  text-[#6060c0] border-b border-[#101020]
+                  transition-colors duration-100
+                  hover:bg-[#181840]
+                  ${index === playlist.currentIndex ? 'bg-gradient-to-b from-[#202060] to-[#101040] text-[#a0a0ff]' : ''}
+                  ${index === playlist.playingIndex ? 'text-[#40ff40]' : ''}
+                `}
+              >
+                {index === playlist.playingIndex && (
+                  <span className="text-[8px] text-[#40ff40] mr-1">▶</span>
+                )}
+                <span className="w-6 text-[10px] text-[#303080] text-right">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                  {item.title || item.mdxFilename}
+                </span>
+                {item.title && (
+                  <span className="text-[9px] text-[#303080] max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap">
+                    {item.mdxFilename}
+                  </span>
+                )}
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -248,6 +248,30 @@
     background: linear-gradient(to bottom, #004400 0%, #002200 100%);
     color: #40ff40;
   }
+
+  /* Playlist Button */
+  .mmdsp-playlist-btn {
+    background: linear-gradient(to bottom, #202050 0%, #101030 100%);
+    border: 1px solid #202048;
+    border-radius: 2px;
+    color: #303080;
+    font-family: inherit;
+    font-size: 9px;
+    padding: 2px 6px;
+    cursor: pointer;
+    transition: all 0.1s;
+  }
+
+  .mmdsp-playlist-btn:hover {
+    background: linear-gradient(to bottom, #303070 0%, #202050 100%);
+    color: #60a0ff;
+  }
+
+  .mmdsp-playlist-btn.active {
+    background: linear-gradient(to bottom, #204060 0%, #103050 100%);
+    color: #40ff40;
+    border-color: #306080;
+  }
 }
 
 /* Mobile Responsive */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,3 +97,20 @@ export interface LevelMeterColors {
 }
 
 export type VisualizerTab = 'keyboard' | 'level' | 'opm';
+
+// Playlist Types
+export interface PlaylistItem {
+  id: string;
+  mdxFilename: string;
+  mdxData: ArrayBuffer;
+  pdxFilename: string | null;
+  pdxData: ArrayBuffer | null;
+  title: string | null;
+}
+
+export interface PlaylistState {
+  items: PlaylistItem[];
+  currentIndex: number;    // Selected index
+  playingIndex: number;    // Currently playing index
+  isAutoPlay: boolean;     // Auto-play next song
+}


### PR DESCRIPTION
## Summary
- D&Dで曲をプレイリストに追加（MDX/PDX/ZIP対応）
- ZIPファイル展開対応（JSZip使用）
- カーソルキー/マウスで選択、Enter/Space/ダブルクリックで再生
- 2ループ後に次の曲を自動再生（AUTOボタンで切替可能）
- タイトル更新のタイミング問題を修正（曲切替時に500ms間は古いタイトルを無視）

## 変更ファイル
- `mdx/` - 純粋HTML/JS/CSS版
- `src/` - Vite React TypeScript版
- 両方のバージョンで同機能を実装

## Test plan
- [ ] 単体MDX/PDXファイルをD&D → プレイリストに追加されることを確認
- [ ] 複数ファイルを同時にD&D → すべて追加されることを確認
- [ ] ZIPファイルをD&D → 中のMDX/PDXが展開・追加されることを確認
- [ ] カーソルキーで選択移動 → UIが追従することを確認
- [ ] Enter/Space/ダブルクリックで再生 → 曲が切り替わることを確認
- [ ] 1曲終了後（2ループ後）→ 次の曲が自動再生されることを確認
- [ ] AUTOボタンOFF → 自動再生が無効になることを確認
- [ ] 曲切替時にタイトルが正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)